### PR TITLE
Fix background image de portada

### DIFF
--- a/app/home/static/css/section.css
+++ b/app/home/static/css/section.css
@@ -59,27 +59,15 @@
   padding-right: 0;
   padding-left: 0;
   overflow-x: hidden;
-  overflow-y: hidden; }
+  overflow-y: hidden;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center; }
   .portada-seccion h1 {
     padding: 6rem 0;
     color: black;
     font-weight: 600;
     text-shadow: 0 3px 6px rgba(0, 0, 0, 0.34); }
-    .portada-seccion .bgimg-container {
-      position: relative; }
-      .portada-seccion .bgimg {
-        z-index: -2;
-        position: absolute;
-        max-width: none;
-        transform: translateX(-60%) translateY(-10%); }
-        @media (min-width: 768px) {
-          .portada-seccion .bgimg {
-            transform: translateX(-50%) translateY(-20%);   }
-}
-          @media (min-width: 992px) {
-            .portada-seccion .bgimg {
-              width: 100%;   }
-}
 
 .nav-secondary {
   background-color: #f8eeff;

--- a/app/home/static/scss/section.scss
+++ b/app/home/static/scss/section.scss
@@ -35,27 +35,14 @@ body {overflow-x: hidden;}
     padding-left:0;
     overflow-x:hidden;
     overflow-y:hidden;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center; 
     h1 {
         padding: 6rem 0;
         color: black;
         font-weight: 600;
         text-shadow: 0 3px 6px rgba(0, 0, 0, 0.34);
-    }
-    .bgimg-container{
-        position: relative;
-    }
-    .bgimg{
-        /* la navbar es -1 */
-        z-index: -2;
-        position: absolute;
-        max-width: none;
-        transform: translateX(-60%) translateY(-10%);
-        @media (min-width: $width-medium) {
-            transform: translateX(-50%) translateY(-20%);
-        }
-        @media (min-width: $width-large) {
-            width:100%;
-        }
     }
  }
 

--- a/app/home/templates/causa_sections/causa_landing.html
+++ b/app/home/templates/causa_sections/causa_landing.html
@@ -1,7 +1,7 @@
-<section class="portada-seccion jumbotron mt-0 text-center">
-    <div class="bgimg-container">
-        <img class="bgimg" src="{{ create_img_src(dimgs['fondo'], isstatic) }}">
-    </div>
+{% set bgimage = create_img_src(dimgs['fondo'], isstatic).strip() %}
+
+<section class="portada-seccion jumbotron mt-0 text-center" 
+    style="background-image: url('{{bgimage}}');">
     <h1 class="my-5">{{dtextos.get('portada')['titulo']}}</h1>
    <!--  <ul id="nav-secondary" class="nav nav-secondary justify-content-center">
         <li class="nav-item">


### PR DESCRIPTION
Con este fix, la imagen de fondo pasa a ocupar todo el ancho de la portada sin sobresalir del contenedor.
<img width="1438" alt="Screen Shot 2019-07-15 at 9 20 03 PM" src="https://user-images.githubusercontent.com/17069884/61257356-14809b00-a747-11e9-8914-d1172f22c981.png">
<img width="368" alt="Screen Shot 2019-07-15 at 9 27 37 PM" src="https://user-images.githubusercontent.com/17069884/61257457-717c5100-a747-11e9-9f3f-ccd2332d109c.png">

